### PR TITLE
Add user schema for Firestore documents

### DIFF
--- a/user-schema.json
+++ b/user-schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "User",
+  "description": "Schema for user documents in Firestore",
+  "type": "object",
+  "properties": {
+    "email": {
+      "description": "The email address of the user",
+      "type": "string",
+      "format": "email"
+    },
+    "display_name": {
+      "description": "The display name of the user",
+      "type": "string"
+    },
+    "photo_url": {
+      "description": "The URL or path of the user's profile photo",
+      "type": "string",
+      "format": "uri"
+    },
+    "uid": {
+      "description": "The unique identifier of the user",
+      "type": "string"
+    },
+    "created_time": {
+      "description": "The time when the user was created",
+      "type": "string",
+      "format": "date-time"
+    },
+    "phone_number": {
+      "description": "The user's phone number",
+      "type": "string"
+    },
+    "birthday": {
+      "description": "The user's birthday",
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "required": ["email", "display_name", "uid", "created_time"]
+}


### PR DESCRIPTION
This JSON schema defines the structure for user documents in Firestore, including required fields and their types.