### PR TITLE
Add JSON schema for Firestore task documents

### DIFF
--- a/task-schema.json
+++ b/task-schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Task",
+  "description": "Schema for task documents in Firestore",
+  "type": "object",
+  "properties": {
+    "title": {
+      "description": "The title of the task",
+      "type": "string"
+    },
+    "details": {
+      "description": "The details of the task",
+      "type": "string"
+    },
+    "completed": {
+      "description": "Status of the task completion",
+      "type": "boolean"
+    },
+    "user": {
+      "description": "Reference to the user who created the task",
+      "type": "string"
+    },
+    "created": {
+      "description": "The time when the task was created",
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "required": ["completed", "created", "title", "user"]
+}


### PR DESCRIPTION
Defines a JSON schema for task documents in Firestore, including properties like title, details, completed status, user reference, and creation time.